### PR TITLE
Return detailed project directory structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ dependencies = [
  "actix-cors",
  "actix-web",
  "regex",
+ "serde",
  "walkdir",
 ]
 
@@ -856,9 +857,23 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ regex = "1.6.0"
 walkdir = "2.3.2"
 actix-web = "4"
 actix-cors = "0.6.2"
+serde = { version = "1.0.145", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 pub mod project;
 
+use std::collections::HashMap;
+
 use actix_web::{get, post, web, App, HttpResponse, HttpServer, Responder};
 use actix_cors::Cors;
 
@@ -21,7 +23,7 @@ fn is_project_descriptor(filename: &str, project_files: &Vec<&str>) -> bool {
     project_files.contains(&filename)
 }
 
-fn get_projects_in_path(path: &str, ignore_dirs: &Vec<&str>, project_files: &Vec<&str>)-> Vec<String> {
+fn get_projects_in_path(path: &str, ignore_dirs: &Vec<&str>, project_files: &Vec<&str>)-> Vec<Project> {
     let mut project_dirs: Vec<DirEntry> = Vec::new();
 
     let walker = WalkDir::new(path).into_iter();
@@ -36,16 +38,42 @@ fn get_projects_in_path(path: &str, ignore_dirs: &Vec<&str>, project_files: &Vec
                 .unwrap_or(false)
         })
     {
-        // println!("{}", &entry.as_ref().unwrap().path().display());
+        println!("{}", &entry.as_ref().unwrap().path().display());
         let e = entry.unwrap().clone();
         project_dirs.push(e);
     }
 
 
     project_dirs.iter().map(|e| {
-        e.path().to_str().unwrap().to_owned()
+        let ev = e.path().to_owned();
+        let mut p = Project::new(ev.parent().unwrap().to_str().unwrap(), ev.to_str().unwrap());
+        p.set_project_type(ev.file_name().unwrap().to_str().unwrap());
+        p
     }).collect()
 
+}
+
+fn project_root_projects(dirs : &Vec<String>, root : &str){
+
+    let mut root_dirs = HashMap::<&str, ProjectHolder>::new();
+
+    for dir in dirs {
+        let suffix = dir.strip_prefix(root).unwrap();
+        
+        if root_dirs.contains_key(suffix) {
+
+            
+            root_dirs.get_mut(suffix).unwrap().add_project(Project::new(suffix, dir));
+            // project_holder = root_dirs.get(suffix).unwrap().clone();
+        } else {
+            let mut project_holder = ProjectHolder::new(suffix.to_string());
+            project_holder.add_project(Project::new(suffix, dir));
+            root_dirs.insert(suffix, project_holder);
+        }
+
+    }
+
+    println!("{:#?}", root_dirs);
 }
 
 async fn res() -> impl Responder{
@@ -54,12 +82,18 @@ async fn res() -> impl Responder{
     let project_files = vec!["Cargo.toml", "package.json", "CMakeLists.txt", "pom.xml", ];
 
     let projects =  get_projects_in_path(&path, &ignore_dirs, &project_files);
+    // x(&projects, &path);
 
     HttpResponse::Ok().json(projects)
 }
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()>{
+
+    // res().await;
+
+    // return Ok(());
+
     HttpServer::new(|| {
         App::new()
             .wrap(

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,3 +1,5 @@
+use serde::{Serialize, Deserialize};
+
 #[derive(Debug)]
 pub struct ProjectHolder {
     pub name: String,
@@ -26,7 +28,7 @@ impl ProjectHolder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Project {
     name: String,
     path: String,
@@ -36,6 +38,10 @@ pub struct Project {
 impl Project {
     pub fn new(name: &str, path: &str) -> Self {
         Project { name: String::from(name) , path: String::from(path) , project_type: String::from("") }
+    }
+
+    pub fn new_with_type(name: &str, path: &str, project_type: &str) -> Self {
+        Project { name: String::from(name) , path: String::from(path) , project_type: String::from(project_type) }
     }
 
     pub fn set_project_type(&mut self, project_type: &str) {


### PR DESCRIPTION
Now use a dedicated `Project` datatype to store `name`, `path`, and `filetype` information. Serialized this struct using serde and returning this value through json on request. 